### PR TITLE
corrected one click link to direct to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Respository of my personal website 
 
-Live at: [ignaciocabeza.com](ignaciocabeza.com)
+Live at: [ignaciocabeza.com](https://ignaciocabeza.com/)
 
 ## Notes
 


### PR DESCRIPTION
Previously the url of clicking the website link is https://github.com/ignaciocabeza/ignacio-cabeza-site/blob/master/ignaciocabeza.com due to markdown relative links

Now it directs to the actual website
